### PR TITLE
Ajout de la possibilité d'ajouter des références d'ArchiveUnit dans une ArchiveUnit

### DIFF
--- a/src/main/java/fr/xelians/sipg/model/ArchiveUnit.java
+++ b/src/main/java/fr/xelians/sipg/model/ArchiveUnit.java
@@ -115,6 +115,11 @@ public class ArchiveUnit implements ArchiveUnitContainer {
     protected final List<ArchiveUnit> archiveUnits = new ArrayList<>();
 
     /**
+     * La liste des archives unites référencées par cette unité d'archive.
+     */
+    protected final List<ArchiveUnitRef> references = new ArrayList<>();
+
+    /**
      * L'identifiant unique de l'archive unit dans le document.
      */
     protected String id;
@@ -1979,6 +1984,36 @@ public class ArchiveUnit implements ArchiveUnitContainer {
         return new ArrayList<>(archiveUnits);
     }
 
+    /**
+     * Ajoute une référence d'unité d'archive à la liste d'autres unités d'archives référencées par cette unité d'archive
+     *
+     * @param reference référence à l'unité d'archive
+     */
+    public void addReference(ArchiveUnitRef reference) {
+        Validate.notNull(reference, SipUtils.NOT_NULL, "reference");
+	    references.add(reference);
+    }
+
+    /**
+     * Supprime une référence d'unité d'archive de la liste d'autres références d'unités d'archives contenues dans cette unité d'archive.
+     *
+     * @param reference la référence d'unité d'archive à supprimer
+     * @return true si la suppression a été réalisée avec succès, sinon false
+     */
+    public boolean removeReference(ArchiveUnitRef reference) {
+        Validate.notNull(reference, SipUtils.NOT_NULL, "reference");
+        return references.remove(reference);
+    }
+
+    /**
+     * Fournit la liste d'autres références d'unités d'archives contenues dans cette unité d'archive.
+     *
+     * @return la liste d'autres références d'unités d'archives
+     */
+    public List<ArchiveUnitRef> getReferences() {
+        return new ArrayList<>(references);
+    }
+    
     /**
      * Ajoute l'élément à la liste des éléments étendus qui n'appartiennent pas à l'ontolgie standard.
      *

--- a/src/main/java/fr/xelians/sipg/service/sedav2/Sedav2Converter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedav2/Sedav2Converter.java
@@ -444,7 +444,26 @@ class Sedav2Converter {
         aut.setContent(dmct);
         unit.getArchiveUnits().forEach(u -> aut.getArchiveUnitOrDataObjectReferenceOrDataObjectGroup().add(toArchiveUnitType(u, dopt)));
 
+        setArchiveUnitReferences(unit, aut);
+
         return aut;
+    }
+
+    private void setArchiveUnitReferences(ArchiveUnit unit, ArchiveUnitType aut) {
+        for (ArchiveUnitRef ref : unit.getReferences()) {
+            postProcessors.add(() -> {
+                ArchiveUnit au = ref.getReference();
+                ArchiveUnitType reference = archiveMap.get(au);
+                if (reference == null) {
+                    throw new SipgException("The related referenced archive unit does not exist in this archive");
+                }
+                ArchiveUnitType referenceArchiveUnitType = new ArchiveUnitType();
+
+                referenceArchiveUnitType.setId(incAndGetCounter());
+                referenceArchiveUnitType.setArchiveUnitRefId(reference);
+                aut.getArchiveUnitOrDataObjectReferenceOrDataObjectGroup().add(referenceArchiveUnitType);
+            });
+        }
     }
 
     private Node toNode(String fragment) {

--- a/src/test/java/fr/xelians/sipg/SipFactory.java
+++ b/src/test/java/fr/xelians/sipg/SipFactory.java
@@ -333,6 +333,9 @@ public class SipFactory {
         unit1.addArchiveUnit(unit4);
         archiveTransfer.addArchiveUnit(unit1);
 
+        unit1.addReference(new ArchiveUnitRef(unit2));
+        unit1.addReference(new ArchiveUnitRef(unit3));
+
         return archiveTransfer;
     }
 


### PR DESCRIPTION
Pour une archive-unit (dossier avec deux enfants) on va avoir un contenu comme l'exemple suivant :

<ArchiveUnit id="dossier">
  <Content>...</Content>
  <ArchiveUnit id="id1">
    <ArchiveUnitRefId>fichier1</ArchiveUnitRefId>
  </ArchiveUnit>
</ArchiveUnit>
<ArchiveUnit id="fichier1">
  <Content>...</Content>
</ArchiveUnit>
<ArchiveUnit id="fichier2">
  <Content>...</Content>
</ArchiveUnit>