### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>Xelians/renovate-config"],
+  "enabledManagers": ["maven", "github-actions"]
+}


### PR DESCRIPTION
Enable Renovate for Maven dependencies and GitHub Actions.

Extends the shared `Xelians/renovate-config` for common rules (grouping, scheduling, etc.).