### PR TITLE
Ajout des identifiants XmlId au manifeste SEDA JSON

### DIFF
--- a/.github/workflows/deploy_maven_central.yml
+++ b/.github/workflows/deploy_maven_central.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Java ${{ matrix.java }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/maven_deploy.yml
+++ b/.github/workflows/maven_deploy.yml
@@ -14,7 +14,7 @@ jobs:
     name: Java ${{ matrix.java }}
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Setup Java
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Le standard SEDA JSON est une transposition en JSON de l'ontologie SEDA v2. Le p
 
 Le standard SEDA JSON a pour principales caractéristiques :
 * Couverture de l'ontologie complète du SEDA v2 avec des clés en PascalCase reprenant les noms des éléments XML
-* Absence de mécanisme d'identifiant et de référence : les objets de données sont déclarés directement dans leur unité d'archive et la hiérarchie s'exprime uniquement par imbrication
+* Absence de mécanisme de référence : les objets de données sont déclarés directement dans leur unité d'archive et la hiérarchie s'exprime uniquement par imbrication
+* Identifiants `XmlId` optionnels (générés par défaut) pour identifier de manière unique chaque unité d'archive et chaque objet de données, sans introduire de référence
 * Ordre des clés imposé (miroir de la séquence du XSD SEDA) qui permet un parsing en streaming en une seule passe
 * Validation par un schéma JSON embarqué (structure, clés autorisées, types, longueurs maximales)
 * Extension de l'ontologie autorisée dans l'objet `Content`

--- a/doc/assets/SEDA_JSON.md
+++ b/doc/assets/SEDA_JSON.md
@@ -24,11 +24,18 @@ l'adaptant aux idiomes JSON.
 * **Pas d'identifiants ni de références.** Contrairement au XML (attributs `id`,
   `DataObjectGroup` déclarés en tête de fichier puis référencés par `DataObjectReference`,
   références inter-unités `ArchiveUnitRefId`), le JSON ne comporte aucun mécanisme de référence :
-  * les objets numériques et physiques sont déclarés **directement dans leur unité d'archive**
+  * les objets numériques et physiques sont déclarés directement dans leur unité d'archive
     (`BinaryDataObjects`, `PhysicalDataObjects`) — un groupe d'objets implicite est créé par
     unité ;
-  * la hiérarchie des unités s'exprime **uniquement par imbrication** (`ArchiveUnits` récursif) ;
+  * la hiérarchie des unités s'exprime uniquement par imbrication (`ArchiveUnits` récursif) ;
   * le partage d'un même groupe d'objets entre plusieurs unités n'est pas supporté.
+* **Identifiants `XmlId` (optionnels).** Pour permettre d'identifier de manière unique certains
+  éléments du manifeste, SipG génère par défaut une clé `XmlId` sur chaque unité d'archive
+  (préfixe `AU`), chaque objet binaire (préfixe `BDO`) et chaque objet physique (préfixe `PDO`).
+  Ces identifiants sont uniques dans la totalité du manifeste et commencent toujours par au moins
+  deux lettres. Il s'agit d'identifiants purement descriptifs : ils ne sont jamais référencés
+  ailleurs dans le manifeste (le principe « pas de références » est préservé). La génération des
+  `XmlId` peut être désactivée via l'option `xmlId` de `SedaJsonConfig`.
 * **Clés en PascalCase** reprenant les noms des éléments SEDA XML.
 * **Éléments multivalués → tableaux JSON** avec un nom au pluriel (`ArchiveUnits`, `Tags`,
   `Keywords`, `BinaryDataObjects`, `Writers`, …).
@@ -37,8 +44,8 @@ l'adaptant aux idiomes JSON.
 * **Appariement explicite des règles** : la juxtaposition positionnelle XML
   `<Rule>`/`<StartDate>` devient un tableau d'objets `"Rules": [{"Rule": "…", "StartDate": "…"}]`.
 * **Ordre des clés imposé** : il permet un parsing en streaming en une seule passe.
-* **Éléments étendus** : toute clé non définie par le standard est acceptée **uniquement dans
-  `Content`**.
+* **Éléments étendus** : toute clé non définie par le standard est acceptée uniquement dans
+  `Content`.
 * **Dates** au format ISO-8601 : `yyyy-MM-dd` pour les dates, `yyyy-MM-dd'T'HH:mm:ss` pour les
   dates-heures.
 
@@ -66,8 +73,8 @@ autres objets, l'ordre indiqué dans ce document est l'ordre normatif de génér
 * **Racine** : `SedaJsonVersion` (obligatoirement en premier), `MessageIdentifier?`, `Comment?`,
   `ArchivalAgreement`, `ArchiveUnits?`, `ManagementMetadata?`, `ArchivalAgency`,
   `TransferringAgency?`.
-* **Unité d'archive** : `Management?`, `Content`, `BinaryDataObjects?`, `PhysicalDataObjects?`,
-  `ArchiveUnits?`.
+* **Unité d'archive** : `XmlId?`, `Management?`, `Content`, `BinaryDataObjects?`,
+  `PhysicalDataObjects?`, `ArchiveUnits?`.
 
 ## Référence des clés
 
@@ -94,14 +101,14 @@ identifiant aléatoire (comme pour les générateurs XML). La date du message (`
 
 ### ManagementMetadata
 
-| Clé | Type | Card. | Longueur max |
-|---|---|---|---|
-| `ArchivalProfile` | chaîne | 0..1 | 512 |
-| `ServiceLevel` | chaîne | 0..1 | 512 |
-| `AcquisitionInformation` | chaîne | 0..1 | 512 |
-| `LegalStatus` | chaîne | 0..1 | 512 |
-| `OriginatingAgencyIdentifier` | chaîne | 0..1 | 512 |
-| `SubmissionAgencyIdentifier` | chaîne | 0..1 | 512 |
+| Clé | Type | Card. | Longueur max | SEDA XML |
+|---|---|---|---|---|
+| `ArchivalProfile` | chaîne | 0..1 | 512 | `ArchivalProfile` |
+| `ServiceLevel` | chaîne | 0..1 | 512 | `ServiceLevel` |
+| `AcquisitionInformation` | chaîne | 0..1 | 512 | `AcquisitionInformation` |
+| `LegalStatus` | chaîne | 0..1 | 512 | `LegalStatus` |
+| `OriginatingAgencyIdentifier` | chaîne | 0..1 | 512 | `OriginatingAgencyIdentifier` |
+| `SubmissionAgencyIdentifier` | chaîne | 0..1 | 512 | `SubmissionAgencyIdentifier` |
 
 ### Agence (`ArchivalAgency`, `TransferringAgency`, `OriginatingAgency`, `SubmissionAgency`)
 
@@ -117,13 +124,17 @@ représentables en JSON (voir [constructions non représentables](#constructions
 
 | Clé | Type | Card. | SEDA XML |
 |---|---|---|---|
+| `XmlId` | chaîne (préfixe `AU`) | 0..1 | — (identifiant généré, spécifique JSON) |
 | `Management` | objet | 0..1 | `ArchiveUnit/Management` |
 | `Content` | objet | 1 | `ArchiveUnit/Content` |
 | `BinaryDataObjects` | tableau (max 1000) | 0..1 | `BinaryDataObject*` du groupe d'objets |
 | `PhysicalDataObjects` | tableau (max 1) | 0..1 | `PhysicalDataObject` du groupe d'objets |
 | `ArchiveUnits` | tableau d'unités | 0..1 | `ArchiveUnit*` imbriquées |
 
-L'attribut `id` de l'unité XML n'a pas d'équivalent et est ignoré.
+L'attribut `id` de l'unité XML (issu de `ArchiveUnit.setId`) n'a pas d'équivalent et est ignoré ;
+le `XmlId` est un identifiant distinct, généré par SipG (voir
+[principes de conception](#principes-de-conception)). Il est présent par défaut et peut être omis
+via l'option `xmlId` de `SedaJsonConfig`.
 
 ### Management
 
@@ -232,44 +243,44 @@ L'ordre des clés suit la séquence du XSD `DescriptiveMetadataContentType` :
 
 ### Événement (`LogBook`, `Events`)
 
-| Clé | Type | Card. | Longueur max |
-|---|---|---|---|
-| `EventIdentifier` | chaîne | 0..1 | 512 |
-| `EventTypeCode` | chaîne | 0..1 | 512 |
-| `EventType` | chaîne | 0..1 | 512 |
-| `EventDateTime` | date-heure | 0..1 | 64 |
-| `EventDetail` | chaîne | 0..1 | 512 |
-| `Outcome` | chaîne | 0..1 | 512 |
-| `OutcomeDetail` | chaîne | 0..1 | 512 |
-| `OutcomeDetailMessage` | chaîne | 0..1 | 1024 |
-| `EventDetailData` | chaîne | 0..1 | 1024 |
+| Clé | Type | Card. | Longueur max | SEDA XML |
+|---|---|---|---|---|
+| `EventIdentifier` | chaîne | 0..1 | 512 | `EventIdentifier` |
+| `EventTypeCode` | chaîne | 0..1 | 512 | `EventTypeCode` |
+| `EventType` | chaîne | 0..1 | 512 | `EventType` |
+| `EventDateTime` | date-heure | 0..1 | 64 | `EventDateTime` |
+| `EventDetail` | chaîne | 0..1 | 512 | `EventDetail` |
+| `Outcome` | chaîne | 0..1 | 512 | `Outcome` |
+| `OutcomeDetail` | chaîne | 0..1 | 512 | `OutcomeDetail` |
+| `OutcomeDetailMessage` | chaîne | 0..1 | 1024 | `OutcomeDetailMessage` |
+| `EventDetailData` | chaîne | 0..1 | 1024 | `EventDetailData` |
 
 ### Agent (`Agents`, `AuthorizedAgents`, `Writers`, `Addressees`, `Recipients`, `Transmitters`, `Senders`)
 
 L'ordre suit la séquence du XSD `AgentType` :
 
-| Clé | Type | Card. | Longueur max |
-|---|---|---|---|
-| `FirstName` | chaîne | 0..1 | 512 |
-| `BirthName` | chaîne | 0..1 | 512 |
-| `FullName` | chaîne | 0..1 | 512 |
-| `GivenName` | chaîne | 0..1 | 512 |
-| `Gender` | chaîne | 0..1 | 512 |
-| `BirthDate` | date | 0..1 | — |
-| `BirthPlace` | lieu | 0..1 | — |
-| `DeathDate` | date | 0..1 | — |
-| `DeathPlace` | lieu | 0..1 | — |
-| `Nationalities` | tableau de chaînes | 0..1 | 512 |
-| `Corpname` | chaîne | 0..1 | 512 |
-| `Identifiers` | tableau de chaînes | 0..1 | 512 |
-| `Functions` | tableau de chaînes | 0..1 | 512 |
-| `Activities` | tableau de chaînes | 0..1 | 512 |
-| `Positions` | tableau de chaînes | 0..1 | 512 |
-| `Roles` | tableau de chaînes | 0..1 | 512 |
-| `Mandates` | tableau de chaînes | 0..1 | 512 |
+| Clé | Type | Card. | Longueur max | SEDA XML |
+|---|---|---|---|---|
+| `FirstName` | chaîne | 0..1 | 512 | `FirstName` |
+| `BirthName` | chaîne | 0..1 | 512 | `BirthName` |
+| `FullName` | chaîne | 0..1 | 512 | `FullName` |
+| `GivenName` | chaîne | 0..1 | 512 | `GivenName` |
+| `Gender` | chaîne | 0..1 | 512 | `Gender` |
+| `BirthDate` | date | 0..1 | — | `BirthDate` |
+| `BirthPlace` | lieu | 0..1 | — | `BirthPlace` |
+| `DeathDate` | date | 0..1 | — | `DeathDate` |
+| `DeathPlace` | lieu | 0..1 | — | `DeathPlace` |
+| `Nationalities` | tableau de chaînes | 0..1 | 512 | `Nationality*` |
+| `Corpname` | chaîne | 0..1 | 512 | `Corpname` |
+| `Identifiers` | tableau de chaînes | 0..1 | 512 | `Identifier*` |
+| `Functions` | tableau de chaînes | 0..1 | 512 | `Function*` |
+| `Activities` | tableau de chaînes | 0..1 | 512 | `Activity*` |
+| `Positions` | tableau de chaînes | 0..1 | 512 | `Position*` |
+| `Roles` | tableau de chaînes | 0..1 | 512 | `Role*` |
+| `Mandates` | tableau de chaînes | 0..1 | 512 | `Mandate*` |
 
-Le **signataire** (`Signer`) ajoute `SigningTime?` (date-heure) en dernière position et le
-**valideur** (`Validator`) ajoute `ValidationTime?` (date-heure).
+Le signataire (`Signer`) ajoute `SigningTime?` (date-heure) en dernière position et le
+valideur (`Validator`) ajoute `ValidationTime?` (date-heure).
 
 ### Lieu (`BirthPlace`, `DeathPlace`)
 
@@ -324,6 +335,7 @@ Les objets sont générés dans l'ordre : BinaryMaster, Dissemination, Thumbnail
 
 | Clé | Type | Card. | Longueur max | SEDA XML |
 |---|---|---|---|---|
+| `XmlId` | chaîne (préfixe `BDO`) | 0..1 | 512 | — (identifiant généré, spécifique JSON) |
 | `DataObjectVersion` | chaîne | 0..1 | 512 | `DataObjectVersion` |
 | `Uri` | chaîne | 1 | 1024 | `Uri` |
 | `MessageDigest` | `{"Algorithm" (1), "Value" (1)}` | 1 | 64/1024 | `MessageDigest` + attribut `algorithm` |
@@ -341,6 +353,7 @@ automatiquement et le format est identifié via la librairie Droid lorsqu'il n'e
 
 | Clé | Type | Card. | SEDA XML |
 |---|---|---|---|
+| `XmlId` | chaîne (préfixe `PDO`) | 0..1 | — (identifiant généré, spécifique JSON) |
 | `DataObjectVersion` | chaîne | 0..1 | `DataObjectVersion` |
 | `PhysicalId` | chaîne | 1 | `PhysicalId` |
 | `Measure` | nombre | 0..1 | `PhysicalDimensions` |
@@ -351,7 +364,7 @@ Le SEDA XML autorise plusieurs `Title` et `Description` avec un attribut `xml:la
 JSON impose une clé `Title` de type chaîne (resp. `Description`) et reporte les autres textes dans
 le tableau pluriel `Titles` (resp. `Descriptions`) :
 
-* `Title` reçoit le message du **premier texte sans langue** ; à défaut, celui du premier texte ;
+* `Title` reçoit le message du premier texte sans langue ; à défaut, celui du premier texte ;
 * les autres textes sont placés dans `Titles` : objets `{"Lang": "…", "Value": "…"}` si une langue
   est définie, chaînes sinon.
 
@@ -364,15 +377,15 @@ le tableau pluriel `Titles` (resp. `Descriptions`) :
 
 ## Éléments étendus
 
-Toute clé non définie par le standard est acceptée **uniquement dans `Content`** et doit être
-placée **après** les clés standard. Les règles de transposition des éléments étendus
+Toute clé non définie par le standard est acceptée uniquement dans `Content` et doit être
+placée après les clés standard. Les règles de transposition des éléments étendus
 (`fr.xelians.sipg.model.Element` ou fragments XML bruts) sont les suivantes :
 
-* un élément feuille sans attribut devient une **chaîne** ;
-* un élément avec enfants devient un **objet** ;
-* les **attributs** deviennent des propriétés de l'objet et la valeur texte est placée sous la clé
+* un élément feuille sans attribut devient une chaîne ;
+* un élément avec enfants devient un objet ;
+* les attributs deviennent des propriétés de l'objet et la valeur texte est placée sous la clé
   `"Value"` ;
-* les noms répétés sont fusionnés en **tableau**.
+* les noms répétés sont fusionnés en tableau.
 
 ```json
 {
@@ -388,7 +401,7 @@ strict (l'attribut est ignoré avec un avertissement en mode non strict).
 ## Constructions non représentables
 
 Les constructions suivantes du modèle SipG n'ont pas d'équivalent dans le standard SEDA JSON. En
-mode **strict** (par défaut), leur présence provoque une `SipException` ; en mode **non strict**,
+mode strict (par défaut), leur présence provoque une `SipException` ; en mode non strict,
 elles sont ignorées avec un avertissement :
 
 | Construction | Raison |
@@ -400,7 +413,7 @@ elles sont ignorées avec un avertissement :
 | Éléments étendus des agences (`Agency.addElement`) | le schéma des agences est fermé |
 | `ArchiveDeliveryRequestReply` (DIP) | le standard JSON ne définit que le transfert |
 
-Sont par ailleurs **toujours ignorés** (trace de debug) : la date du message
+Sont par ailleurs toujours ignorés (trace de debug) : la date du message
 (`ArchiveTransfer.setDate`), les `CodeListVersions`, l'identifiant d'unité (`ArchiveUnit.setId`)
 et le `SignatureStatus`.
 
@@ -432,6 +445,7 @@ concernée par cette limite.
   "ArchivalAgreement": "IC-000001",
   "ArchiveUnits": [
     {
+      "XmlId": "AU1",
       "Management": {
         "AppraisalRule": {
           "Rules": [ { "Rule": "APP-00001", "StartDate": "2025-01-01" } ],
@@ -454,6 +468,7 @@ concernée par cette limite.
       },
       "BinaryDataObjects": [
         {
+          "XmlId": "BDO1",
           "DataObjectVersion": "BinaryMaster_1",
           "Uri": "content/1_dossier_durand.pdf",
           "MessageDigest": { "Algorithm": "SHA-512", "Value": "9f2c…" },
@@ -463,10 +478,10 @@ concernée par cette limite.
         }
       ],
       "PhysicalDataObjects": [
-        { "DataObjectVersion": "PhysicalMaster_1", "PhysicalId": "BOITE-42", "Measure": 1.5 }
+        { "XmlId": "PDO1", "DataObjectVersion": "PhysicalMaster_1", "PhysicalId": "BOITE-42", "Measure": 1.5 }
       ],
       "ArchiveUnits": [
-        { "Content": { "DescriptionLevel": "Item", "Title": "Pièce annexe" } }
+        { "XmlId": "AU2", "Content": { "DescriptionLevel": "Item", "Title": "Pièce annexe" } }
       ]
     }
   ],
@@ -486,11 +501,11 @@ standard et sont acceptés uniquement dans `Content`.
 
 La validation d'un paquet zip (`SedaJsonService.validate(Path)`) opère en trois temps :
 
-1. la **validation par schéma** : le manifeste est validé contre le schéma JSON embarqué
+1. la validation par schéma : le manifeste est validé contre le schéma JSON embarqué
    (structure, clés autorisées, types, longueurs maximales) ;
-2. le **parsing en streaming** : l'ordre des clés imposé par le standard est vérifié et les objets
+2. le parsing en streaming : l'ordre des clés imposé par le standard est vérifié et les objets
    binaires sont extraits ;
-3. la **vérification des binaires** : existence, emplacement dans `content/`, taille et empreinte.
+3. la vérification des binaires : existence, emplacement dans `content/`, taille et empreinte.
 
 Chaque étape est notifiée au callback de progression (`ProgressListener<SedaJsonStep>`) :
 
@@ -538,5 +553,6 @@ La configuration `SedaJsonConfig` (créée via `SedaJsonConfigBuilder`) permet d
 la validation par schéma lors de la génération (`validate`), le formatage du manifeste (`format`,
 `indent`), le nombre de threads (`thread`), le mode strict (`strict`), les vérifications des
 binaires (`checkBinary`, `checkSize`, `checkDigest`), la génération en mémoire (`useMemory`),
-l'identification des formats (`identifyFileFormat`) et la taille maximale du manifeste lors de la
-validation (`maxManifestSize`).
+l'identification des formats (`identifyFileFormat`), la génération des identifiants `XmlId`
+(`xmlId`, activée par défaut) et la taille maximale du manifeste lors de la validation
+(`maxManifestSize`).

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.xelians</groupId>
     <artifactId>sipg</artifactId>
-    <version>1.46</version>
+    <version>1.47</version>
     <packaging>jar</packaging>
 
     <organization>
@@ -122,14 +122,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
             </plugin>
 
             <!-- Jacoco code coverage -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
+                <version>0.8.15</version>
                 <configuration>
                     <skip>false</skip>
                 </configuration>
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.21.0</version>
+                <version>3.22.0</version>
             </plugin>
         </plugins>
     </build>
@@ -168,12 +168,12 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>4.0.8</version>
+            <version>4.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.8</version>
+            <version>4.0.9</version>
         </dependency>
         <!-- We need a non-official Xerces 12 to deal with XSD 1.1. Unfortunately the
         official Apache Xerces 12.1 is not released on maven central -->
@@ -200,17 +200,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.21.3</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.21.3</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.3</version>
+            <version>2.22.0</version>
         </dependency>
         <!-- Validation par schéma JSON (manifestes SEDA JSON) -->
         <dependency>
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.18</version>
         </dependency>
 
         <!--  File Format -->
@@ -303,19 +303,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>6.0.3</version>
+            <version>6.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.32</version>
+            <version>1.5.34</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -364,7 +364,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
+                <version>0.8.15</version>
             </plugin>
         </plugins>
     </reporting>
@@ -439,7 +439,7 @@
                     <plugin>
                         <groupId>org.jvnet.jaxb</groupId>
                         <artifactId>jaxb-maven-plugin</artifactId>
-                        <version>4.0.14</version>
+                        <version>4.0.16</version>
                         <executions>
                             <execution>
                                 <configuration>
@@ -464,7 +464,7 @@
                                         <plugin>
                                             <groupId>org.jvnet.jaxb</groupId>
                                             <artifactId>jaxb-plugin-annotate</artifactId>
-                                            <version>4.0.14</version>
+                                            <version>4.0.16</version>
                                         </plugin>
                                     </plugins>
                                 </configuration>
@@ -477,7 +477,7 @@
                             <dependency>
                                 <groupId>org.jvnet.jaxb</groupId>
                                 <artifactId>jaxb-plugins</artifactId>
-                                <version>4.0.14</version>
+                                <version>4.0.16</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -493,7 +493,7 @@
                     <plugin>
                         <groupId>org.jvnet.jaxb</groupId>
                         <artifactId>jaxb-maven-plugin</artifactId>
-                        <version>4.0.14</version>
+                        <version>4.0.16</version>
                         <executions>
                             <execution>
                                 <configuration>
@@ -518,7 +518,7 @@
                                         <plugin>
                                             <groupId>org.jvnet.jaxb</groupId>
                                             <artifactId>jaxb-plugin-annotate</artifactId>
-                                            <version>4.0.14</version>
+                                            <version>4.0.16</version>
                                         </plugin>
                                     </plugins>
                                 </configuration>
@@ -531,7 +531,7 @@
                             <dependency>
                                 <groupId>org.jvnet.jaxb</groupId>
                                 <artifactId>jaxb-plugins</artifactId>
-                                <version>4.0.14</version>
+                                <version>4.0.16</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConfig.java
+++ b/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConfig.java
@@ -35,6 +35,8 @@ package fr.xelians.sipg.service.sedajson;
  * @param useMemory spécifie si la génération du sip utilise la mémoire ou le disque
  * @param identifyFileFormat spécifie si le format de fichier des objets binaires doit être
  *     identifié
+ * @param xmlId spécifie si un identifiant unique XmlId est généré pour chaque unité d'archive et
+ *     chaque objet de données
  * @param maxManifestSize spécifie la taille maximale en octets du manifeste lors de la validation
  * @author Emmanuel Deviller
  * @see SedaJsonConfigBuilder
@@ -50,6 +52,7 @@ public record SedaJsonConfig(
     boolean checkDigest,
     boolean useMemory,
     boolean identifyFileFormat,
+    boolean xmlId,
     long maxManifestSize) {
 
   /** The constant DEFAULT. */

--- a/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConfigBuilder.java
+++ b/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConfigBuilder.java
@@ -40,6 +40,7 @@ public class SedaJsonConfigBuilder {
   private boolean checkDigest = true;
   private boolean useMemory = false;
   private boolean identifyFileFormat = true;
+  private boolean xmlId = true;
   private long maxManifestSize = DEFAULT_MAX_MANIFEST_SIZE;
 
   private SedaJsonConfigBuilder() {}
@@ -172,6 +173,19 @@ public class SedaJsonConfigBuilder {
   }
 
   /**
+   * Spécifie si un identifiant unique XmlId est généré pour chaque unité d'archive (préfixe {@code
+   * AU}), chaque objet de données binaire (préfixe {@code BDO}) et chaque objet de données physique
+   * (préfixe {@code PDO}). L'identifiant est unique dans la totalité du manifeste. True par défaut.
+   *
+   * @param xmlId si un identifiant unique XmlId doit être généré
+   * @return le builder
+   */
+  public SedaJsonConfigBuilder xmlId(boolean xmlId) {
+    this.xmlId = xmlId;
+    return this;
+  }
+
+  /**
    * Spécifie la taille maximale en octets du manifeste lors de la validation. La validation par
    * schéma JSON matérialise le manifeste en mémoire (contrairement à la validation XSD qui opère en
    * streaming), d'où cette limite. 128 Mio par défaut.
@@ -201,6 +215,7 @@ public class SedaJsonConfigBuilder {
         checkDigest,
         useMemory,
         identifyFileFormat,
+        xmlId,
         maxManifestSize);
   }
 }

--- a/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConverter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConverter.java
@@ -87,15 +87,20 @@ class SedaJsonConverter {
 
   private final List<Callable<Void>> tasks = new ArrayList<>();
   private final AtomicInteger idCounter = new AtomicInteger();
+  private final AtomicInteger auCounter = new AtomicInteger();
+  private final AtomicInteger bdoCounter = new AtomicInteger();
+  private final AtomicInteger pdoCounter = new AtomicInteger();
   private final DocumentBuilder documentBuilder;
   private final FileSystem zipArchive;
   private final boolean isStrict;
   private final boolean identifyFileFormat;
+  private final boolean xmlId;
 
   private SedaJsonConverter(FileSystem zipArchive, SedaJsonConfig config) {
     this.zipArchive = zipArchive;
     this.isStrict = config.strict();
     this.identifyFileFormat = config.identifyFileFormat();
+    this.xmlId = config.xmlId();
 
     try {
       documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -229,6 +234,12 @@ class SedaJsonConverter {
 
     ObjectNode node = NF.objectNode();
 
+    // L'XmlId, lorsqu'il est activé, est la première clé de l'unité afin d'identifier de manière
+    // unique l'unité dans la totalité du manifeste (préfixe AU)
+    if (xmlId) {
+      node.put(XML_ID, "AU" + auCounter.incrementAndGet());
+    }
+
     ObjectNode management = toManagement(unit);
     if (!management.isEmpty()) {
       node.set(MANAGEMENT, management);
@@ -244,6 +255,9 @@ class SedaJsonConverter {
     if (StringUtils.isNotBlank(unit.getPhysicalId())) {
       ArrayNode physicalObjects = node.putArray(PHYSICAL_DATA_OBJECTS);
       ObjectNode pdo = physicalObjects.addObject();
+      if (xmlId) {
+        pdo.put(XML_ID, "PDO" + pdoCounter.incrementAndGet());
+      }
       ifNotBlank(unit.getPhysicalVersion(), e -> pdo.put(DATA_OBJECT_VERSION, e));
       pdo.put(PHYSICAL_ID, unit.getPhysicalId());
       if (unit.getMeasure() > 0) {
@@ -874,6 +888,9 @@ class SedaJsonConverter {
     }
 
     ObjectNode node = array.addObject();
+    if (xmlId) {
+      node.put(XML_ID, "BDO" + bdoCounter.incrementAndGet());
+    }
     ifNotBlank(bdo.getBinaryVersion(), e -> node.put(DATA_OBJECT_VERSION, e));
 
     String sanitizedFileName = SipUtils.sanitizeFileName(binaryPath.getFileName().toString());

--- a/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonKeys.java
+++ b/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonKeys.java
@@ -51,6 +51,7 @@ final class SedaJsonKeys {
   static final String NAME = "Name";
 
   // Unité d'archive
+  static final String XML_ID = "XmlId";
   static final String MANAGEMENT = "Management";
   static final String CONTENT = "Content";
   static final String BINARY_DATA_OBJECTS = "BinaryDataObjects";

--- a/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonParser.java
+++ b/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonParser.java
@@ -164,11 +164,12 @@ final class SedaJsonParser {
 
   private static int unitRankOf(String name) {
     return switch (name) {
-      case MANAGEMENT -> 1;
-      case CONTENT -> 2;
-      case BINARY_DATA_OBJECTS -> 3;
-      case PHYSICAL_DATA_OBJECTS -> 4;
-      case ARCHIVE_UNITS -> 5;
+      case XML_ID -> 1;
+      case MANAGEMENT -> 2;
+      case CONTENT -> 3;
+      case BINARY_DATA_OBJECTS -> 4;
+      case PHYSICAL_DATA_OBJECTS -> 5;
+      case ARCHIVE_UNITS -> 6;
       default -> throw unknownKeyException("ArchiveUnit", name);
     };
   }

--- a/src/main/resources/seda-json-2.0-schema.json
+++ b/src/main/resources/seda-json-2.0-schema.json
@@ -43,6 +43,11 @@
       "type": "string",
       "maxLength": 512
     },
+    "xmlId": {
+      "type": "string",
+      "pattern": "^[A-Za-z]{2}",
+      "maxLength": 512
+    },
     "textArray512": {
       "type": "array",
       "maxItems": 1000,
@@ -165,6 +170,9 @@
     "archiveUnit": {
       "type": "object",
       "properties": {
+        "XmlId": {
+          "$ref": "#/$defs/xmlId"
+        },
         "Management": {
           "$ref": "#/$defs/management"
         },
@@ -1156,6 +1164,9 @@
     "binaryDataObject": {
       "type": "object",
       "properties": {
+        "XmlId": {
+          "$ref": "#/$defs/xmlId"
+        },
         "DataObjectVersion": {
           "$ref": "#/$defs/text512"
         },
@@ -1256,6 +1267,9 @@
     "physicalDataObject": {
       "type": "object",
       "properties": {
+        "XmlId": {
+          "$ref": "#/$defs/xmlId"
+        },
         "DataObjectVersion": {
           "$ref": "#/$defs/text512"
         },

--- a/src/test/java/fr/xelians/sipg/service/sedajson/SedaJsonTest.java
+++ b/src/test/java/fr/xelians/sipg/service/sedajson/SedaJsonTest.java
@@ -67,6 +67,10 @@ class SedaJsonTest {
 
   private final SedaJsonConfig jsonConfig =
       SedaJsonConfigBuilder.builder().format(true).validate(true).strict(false).build();
+  // L'XmlId est une extension sipg absente du sous-ensemble esafe : on le désactive pour valider
+  // la sortie canonique contre le schéma esafe externe
+  private final SedaJsonConfig noXmlIdConfig =
+      SedaJsonConfigBuilder.builder().strict(false).xmlId(false).build();
   private final SedaJsonService jsonService = SedaJsonService.getInstance();
 
   private JsonNode readManifest(Path zipPath) throws Exception {
@@ -106,10 +110,14 @@ class SedaJsonTest {
             "TransferringAgency"),
         fieldNames(manifest));
     JsonNode unit = manifest.get("ArchiveUnits").get(0);
-    assertEquals(List.of("Content", "BinaryDataObjects"), fieldNames(unit));
+    // L'XmlId, activé par défaut, est la première clé de l'unité
+    assertEquals(List.of("XmlId", "Content", "BinaryDataObjects"), fieldNames(unit));
+    assertEquals("AU1", unit.get("XmlId").asText());
     assertEquals("My_Title", unit.get("Content").get("Title").asText());
 
     JsonNode binary = unit.get("BinaryDataObjects").get(0);
+    // L'XmlId est également la première clé de l'objet binaire
+    assertEquals("BDO1", binary.get("XmlId").asText());
     assertEquals("content/1_dummy.pdf", binary.get("Uri").asText());
     assertEquals("SHA-512", binary.get("MessageDigest").get("Algorithm").asText());
     assertTrue(binary.get("Size").asLong() > 0);
@@ -368,7 +376,7 @@ class SedaJsonTest {
               .getSchema(MAPPER.readTree(is));
     }
 
-    try (InputStream is = jsonService.marshal(archiveTransfer)) {
+    try (InputStream is = jsonService.marshal(archiveTransfer, noXmlIdConfig)) {
       Set<ValidationMessage> messages = esafeSchema.validate(MAPPER.readTree(is));
       assertTrue(messages.isEmpty(), messages.toString());
     }
@@ -388,10 +396,51 @@ class SedaJsonTest {
                 .getSchema(MAPPER.readTree(is));
       }
 
-      try (InputStream is = jsonService.marshal(archiveTransfer, jsonConfig)) {
+      try (InputStream is = jsonService.marshal(archiveTransfer, noXmlIdConfig)) {
         Set<ValidationMessage> messages = esafeSchema.validate(MAPPER.readTree(is));
         assertTrue(messages.isEmpty(), messages.toString());
       }
+    }
+  }
+
+  /** Test the XmlId generation, uniqueness and disabling. */
+  @Test
+  void testXmlId() throws Exception {
+    try (FileSystem fs = Jimfs.newFileSystem()) {
+      ArchiveTransfer archiveTransfer = SipFactory.createComplexSip(fs);
+
+      // XmlId activé par défaut : chaque unité, objet binaire et objet physique en porte un, unique
+      // dans la totalité du manifeste et préfixé par au moins deux lettres (AU, BDO, PDO)
+      try (InputStream is = jsonService.marshal(archiveTransfer, jsonConfig)) {
+        JsonNode manifest = MAPPER.readTree(is);
+        List<String> ids = new ArrayList<>();
+        collectXmlIds(manifest, ids);
+        assertFalse(ids.isEmpty());
+        assertEquals(ids.size(), Set.copyOf(ids).size(), "XmlId must be unique: " + ids);
+        for (String id : ids) {
+          assertTrue(id.matches("^(AU|BDO|PDO)\\d+$"), "XmlId must start with 2+ letters: " + id);
+        }
+      }
+
+      // XmlId désactivé : aucune clé XmlId n'est générée
+      try (InputStream is = jsonService.marshal(archiveTransfer, noXmlIdConfig)) {
+        JsonNode manifest = MAPPER.readTree(is);
+        List<String> ids = new ArrayList<>();
+        collectXmlIds(manifest, ids);
+        assertTrue(ids.isEmpty(), "No XmlId expected when disabled: " + ids);
+      }
+    }
+  }
+
+  private static void collectXmlIds(JsonNode node, List<String> ids) {
+    if (node.isObject()) {
+      JsonNode id = node.get("XmlId");
+      if (id != null) {
+        ids.add(id.asText());
+      }
+      node.fields().forEachRemaining(e -> collectXmlIds(e.getValue(), ids));
+    } else if (node.isArray()) {
+      node.forEach(child -> collectXmlIds(child, ids));
     }
   }
 }


### PR DESCRIPTION
## Résumé

Ajoute la possibilité d'identifier de manière unique certains éléments du manifeste SEDA JSON généré, et applique les mises à jour de dépendances Renovate en attente.

### Fonctionnalité XmlId
- Génère un `XmlId` unique sur chaque `ArchiveUnit` (préfixe `AU`), `BinaryDataObject` (`BDO`) et `PhysicalDataObject` (`PDO`).
- Chaque identifiant est unique dans la totalité du manifeste et commence par au moins deux lettres ; il est inséré en première clé de son objet.
- Génération pilotée par la nouvelle option `SedaJsonConfig.xmlId` (**activée par défaut**).
- Parser en streaming, schéma JSON embarqué, tests et documentation (`SEDA_JSON.md`, `README.md`) mis à jour en conséquence.

### Mises à jour de dépendances (Renovate)
- jackson 2.21.3 → 2.22.0
- jaxb-ri 4.0.8 → 4.0.9, plugins jaxb maven 4.0.14 → 4.0.16
- junit 6.0.3 → 6.1.0, logback 1.5.32 → 1.5.34, slf4j 2.0.17 → 2.0.18
- xom 1.4.1 → 1.4.5
- maven-surefire-plugin 3.5.5 → 3.5.6, maven-site-plugin 3.21.0 → 3.22.0
- jacoco-maven-plugin 0.8.14 → 0.8.15
- actions/checkout → df4cb1c (3 workflows)

### Tests
`mvn test` : 132 tests, 0 échec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)