### PR TITLE
chore: refactor DroidUtils and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.xelians</groupId>
     <artifactId>sipg</artifactId>
-    <version>1.47</version>
+    <version>1.48</version>
     <packaging>jar</packaging>
 
     <organization>
@@ -239,6 +239,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
         </dependency>
 
         <!--  Log -->

--- a/src/main/java/fr/xelians/sipg/service/fntcv4/Fntcv4Converter.java
+++ b/src/main/java/fr/xelians/sipg/service/fntcv4/Fntcv4Converter.java
@@ -793,7 +793,8 @@ class Fntcv4Converter {
         // jimfs)
         if (StringUtils.isBlank(bdot.getFormat())) {
           String ext = FilenameUtils.getExtension(binaryPath.getFileName().toString());
-          List<IdentificationResult> results = DroidUtils.matchBinarySignatures(binaryPath, ext);
+          List<IdentificationResult> results =
+              DroidUtils.matchBinarySignatures(binaryPath, ext, true);
           String format = results.isEmpty() ? "Unknown Format" : results.get(0).getPuid();
           bdot.setFormat(format);
         }

--- a/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConverter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedajson/SedaJsonConverter.java
@@ -1043,7 +1043,7 @@ class SedaJsonConverter {
 
       ObjectNode format = (ObjectNode) formatNode;
       String ext = FilenameUtils.getExtension(binaryPath.getFileName().toString());
-      List<IdentificationResult> results = DroidUtils.matchBinarySignatures(binaryPath, ext);
+      List<IdentificationResult> results = DroidUtils.matchBinarySignatures(binaryPath, ext, true);
       if (results.isEmpty()) {
         format.put(FORMAT_ID, "Unknown");
       } else {

--- a/src/main/java/fr/xelians/sipg/service/sedav2/seda21/Sedav21Converter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedav2/seda21/Sedav21Converter.java
@@ -1272,7 +1272,8 @@ class Sedav21Converter {
         // Note. The Signature Identifier does not fully support NIO2 (i.e. does not work with
         // jimfs)
         String ext = FilenameUtils.getExtension(binaryPath.getFileName().toString());
-        List<IdentificationResult> results = DroidUtils.matchBinarySignatures(binaryPath, ext);
+        List<IdentificationResult> results =
+            DroidUtils.matchBinarySignatures(binaryPath, ext, true);
         if (results.isEmpty()) {
           bdot.setFormatIdentification(toFormatIdentificationType("Unknown", null, null));
         } else {

--- a/src/main/java/fr/xelians/sipg/service/sedav2/seda22/Sedav22Converter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedav2/seda22/Sedav22Converter.java
@@ -1392,7 +1392,8 @@ class Sedav22Converter {
         // Note. The Signature Identifier does not fully support NIO2 (i.e. does not work with
         // jimfs)
         String ext = FilenameUtils.getExtension(binaryPath.getFileName().toString());
-        List<IdentificationResult> results = DroidUtils.matchBinarySignatures(binaryPath, ext);
+        List<IdentificationResult> results =
+            DroidUtils.matchBinarySignatures(binaryPath, ext, true);
         if (results.isEmpty()) {
           bdot.setFormatIdentification(toFormatIdentificationType("Unknown", null, null));
         } else {

--- a/src/main/java/fr/xelians/sipg/service/sedav2/seda22/Sedav22Converter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedav2/seda22/Sedav22Converter.java
@@ -1397,7 +1397,7 @@ class Sedav22Converter {
         if (results.isEmpty()) {
           bdot.setFormatIdentification(toFormatIdentificationType("Unknown", null, null));
         } else {
-          IdentificationResult r = results.get(0);
+          IdentificationResult r = results.getFirst();
           String name =
               StringUtils.isAllBlank(r.getName(), r.getVersion())
                   ? null

--- a/src/main/java/fr/xelians/sipg/service/sedav2/seda23/Sedav23Converter.java
+++ b/src/main/java/fr/xelians/sipg/service/sedav2/seda23/Sedav23Converter.java
@@ -1416,7 +1416,8 @@ class Sedav23Converter {
         // Note. The Signature Identifier does not fully support NIO2 (i.e. does not work with
         // jimfs)
         String ext = FilenameUtils.getExtension(binaryPath.getFileName().toString());
-        List<IdentificationResult> results = DroidUtils.matchBinarySignatures(binaryPath, ext);
+        List<IdentificationResult> results =
+            DroidUtils.matchBinarySignatures(binaryPath, ext, true);
         if (results.isEmpty()) {
           bdot.setFormatIdentification(toFormatIdentificationType("Unknown", null, null));
         } else {

--- a/src/main/java/fr/xelians/sipg/utils/DroidUtils.java
+++ b/src/main/java/fr/xelians/sipg/utils/DroidUtils.java
@@ -91,8 +91,9 @@ public final class DroidUtils {
     RequestIdentifier identifier = new RequestIdentifier(path.toUri());
     identifier.setParentId(1L);
 
-    try (IdentificationRequest<Path> request =
+    try (FileSystemIdentificationRequest request =
         new FileSystemIdentificationRequest(createMetadata(path), identifier)) {
+      request.setExtension(extension);
       request.open(path);
 
       // Optimized path

--- a/src/main/java/fr/xelians/sipg/utils/DroidUtils.java
+++ b/src/main/java/fr/xelians/sipg/utils/DroidUtils.java
@@ -1,7 +1,5 @@
 package fr.xelians.sipg.utils;
 
-import static fr.xelians.sipg.utils.SipUtils.NOT_NULL;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -10,6 +8,9 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
 import uk.gov.nationalarchives.droid.core.IdentificationRequestByteReaderAdapter;
 import uk.gov.nationalarchives.droid.core.SignatureParseException;
@@ -17,26 +18,21 @@ import uk.gov.nationalarchives.droid.core.interfaces.*;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.FileSystemIdentificationRequest;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 import uk.gov.nationalarchives.droid.core.signature.ByteReader;
-import uk.gov.nationalarchives.droid.core.signature.FileFormat;
 import uk.gov.nationalarchives.droid.core.signature.FileFormatHit;
 import uk.gov.nationalarchives.droid.core.signature.droid6.InternalSignature;
 
-/**
- * La classe DroidUtils offre des méthodes statiques utilitaires. Note. Il est fortement déconseillé
- * d'utiliser cette classe en dehors de la librairie.
- *
+/*
  * @author Emmanuel Deviller
  */
 public final class DroidUtils {
 
-  private static final String[] EXTENSIONS = {
-    "PDF", "JPG", "JPEG", "TIF", "TIFF", "PNG", "XML", "TXT", "CSV", "DOC", "DOCX", "XLS", "XLSX",
-    "ZIP"
-  };
+  private static final Logger LOGGER = LoggerFactory.getLogger(DroidUtils.class);
 
-  private static final Map<String, List<InternalSignature>> SIGNATURES_BY_ID = new HashMap<>();
-
+  private static final Map<String, List<InternalSignature>> SIGNATURES = new HashMap<>();
   private static final long MAX_BYTES_TO_SCAN = -1L; // Scan all bytes
+
+  private static final String SIGNATURE_PATH_MUST_NOT_BE_NULL = "signaturePath must not be null";
+  private static final String PATH_MUST_NOT_BE_NULL = "path must not be null";
 
   // Plain text and json have no binary signature in Droid, so they are identified by extension.
   private static final List<IdentificationResult> PLAIN_TEXT_RESULT =
@@ -57,51 +53,8 @@ public final class DroidUtils {
     return result;
   }
 
-  /**
-   * Initialise les identifiants binaires des signatures Droid à partir de la ressource par défaut.
-   *
-   * @return les identifiants binaires des signatures
-   */
-  private static BinarySignatureIdentifier initDroidSignatures() {
-    Path signatureTmpPath = null;
-    try (InputStream is = SipUtils.resourceAsStream("droid_signaturefile.xml")) {
-      if (is != null) {
-        signatureTmpPath = Files.createTempFile("droid", ".xml");
-        Files.copy(is, signatureTmpPath, StandardCopyOption.REPLACE_EXISTING);
-        BinarySignatureIdentifier bsi = initDroidSignatures(signatureTmpPath);
-        List.of(EXTENSIONS)
-            .forEach(
-                ext -> {
-                  List<InternalSignature> isigs = buildInternalSignatures(bsi, ext);
-                  if (!isigs.isEmpty()) {
-                    SIGNATURES_BY_ID.put(ext, isigs);
-                  }
-                });
-        return bsi;
-      }
-      throw new SipException("Unable to found Droid droid_signaturefile.xml in resource");
-    } catch (IOException ex) {
-      throw new SipException("Unable to init Droid signatures identifier", ex);
-    } finally {
-      if (signatureTmpPath != null) {
-        try {
-          Files.deleteIfExists(signatureTmpPath);
-        } catch (IOException e) {
-          // Ignore
-        }
-      }
-    }
-  }
-
-  /**
-   * Initialise les identifiants binaires des signatures Droid à partir d'un fichier de signature.
-   * Note. Le fichier de signatures doit se trouver sur le système de fichier par défaut.
-   *
-   * @param signaturePath le path du fichier de signature
-   * @return les identifiants binaires des signatures
-   */
   public static BinarySignatureIdentifier initDroidSignatures(Path signaturePath) {
-    Validate.notNull(signaturePath, NOT_NULL, "signaturePath");
+    Validate.notNull(signaturePath, SIGNATURE_PATH_MUST_NOT_BE_NULL);
 
     try {
       BinarySignatureIdentifier bsi = new BinarySignatureIdentifier();
@@ -114,51 +67,37 @@ public final class DroidUtils {
     }
   }
 
-  public static boolean isSupportedFormat(String puid) {
-    return DroidSignaturesHolder.INSTANCE.getSigFile().getFileFormat(puid) != null;
+  public static boolean isSupportedFormat(@Nullable String puid) {
+    return StringUtils.isNotBlank(puid)
+        && DroidSignaturesHolder.INSTANCE.getSigFile().getFileFormat(puid) != null;
   }
 
-  public static boolean isSupportedExtension(String ext) {
-    return ext != null && SIGNATURES_BY_ID.containsKey(ext.toUpperCase());
+  public static boolean isSupportedExtension(@Nullable String ext) {
+    return StringUtils.isNotBlank(ext) && SIGNATURES.containsKey(ext.toUpperCase());
   }
 
-  /**
-   * Identifie le format du fichier spécifié par le path en utilisant les identifiants binaire des
-   * signatures par défaut. Note. Les paths vers un système de fichier virtuel (ie. zip) ne sont pas
-   * supportés.
-   *
-   * @param path le path du fichier à identifier
-   * @param extension l'extension du fichier à identifier
-   * @return la liste de résultats de l'identification.
-   */
-  public static List<IdentificationResult> matchBinarySignatures(Path path, String extension) {
-    Validate.notNull(path, NOT_NULL, "path");
-    return matchBinarySignatures(path, extension, DroidSignaturesHolder.INSTANCE);
-  }
-
-  /**
-   * Identifie le format du fichier spécifié par le path en utilisant les identifiants binaire des
-   * signatures par défaut. Note. Les paths vers un système de fichier virtuel (ie. zip) ne sont pas
-   * supportés.
-   *
-   * @param path le path du fichier à identifier
-   * @param extension l'extension du fichier à identifier
-   * @param bsi les identifiants binaires des signatures
-   * @return la liste de résultats de l'identification.
-   */
   public static List<IdentificationResult> matchBinarySignatures(
-      Path path, String extension, BinarySignatureIdentifier bsi) {
+      Path path, @Nullable String extension, boolean matchExtension) {
+    Validate.notNull(path, PATH_MUST_NOT_BE_NULL);
+    return matchBinarySignatures(path, extension, DroidSignaturesHolder.INSTANCE, matchExtension);
+  }
+
+  public static List<IdentificationResult> matchBinarySignatures(
+      Path path,
+      @Nullable String extension,
+      BinarySignatureIdentifier bsi,
+      boolean matchExtension) {
 
     RequestIdentifier identifier = new RequestIdentifier(path.toUri());
     identifier.setParentId(1L);
 
-    try (FileSystemIdentificationRequest request =
+    try (IdentificationRequest<Path> request =
         new FileSystemIdentificationRequest(createMetadata(path), identifier)) {
-      request.setExtension(extension);
       request.open(path);
 
-      if (!StringUtils.isBlank(extension)) {
-        List<InternalSignature> intSigs = SIGNATURES_BY_ID.get(extension.toUpperCase());
+      // Optimized path
+      if (StringUtils.isNotBlank(extension)) {
+        List<InternalSignature> intSigs = SIGNATURES.get(extension.toUpperCase());
         if (intSigs != null) {
           List<IdentificationResult> results = matchBinarySignatures(request, intSigs).getResults();
           if (!results.isEmpty()) {
@@ -173,10 +112,22 @@ public final class DroidUtils {
         return results;
       }
 
-      return bsi.matchExtensions(request, true).getResults();
+      if (matchExtension) {
+        return bsi.matchExtensions(request, true).getResults();
+      }
+
+      // Droid has no binary signature for plain text or json, so fall back to the extension.
+      if ("jsn".equalsIgnoreCase(extension) || "json".equalsIgnoreCase(extension)) {
+        return JSON_RESULT;
+      }
+      if ("txt".equalsIgnoreCase(extension) || "text".equalsIgnoreCase(extension)) {
+        return PLAIN_TEXT_RESULT;
+      }
+
+      return Collections.emptyList();
 
     } catch (IOException ex) {
-      throw new SipException("Unable to matchBinarySignatures for " + path, ex);
+      throw new SipException(String.format("Unable to match binary signatures for %s", path), ex);
     }
   }
 
@@ -192,7 +143,7 @@ public final class DroidUtils {
 
     IdentificationResultCollection results = new IdentificationResultCollection(request);
     results.setRequestMetaData(request.getRequestMetaData());
-    ByteReader byteReader = new IdentificationRequestByteReaderAdapter(request);
+    ByteReader<?> byteReader = new IdentificationRequestByteReaderAdapter<>(request);
     runFileIdentification(byteReader, intSigs);
     final int numHits = byteReader.getNumHits();
     for (int i = 0; i < numHits; i++) {
@@ -211,7 +162,7 @@ public final class DroidUtils {
   }
 
   private static void runFileIdentification(
-      final ByteReader targetFile, List<InternalSignature> intSigs) {
+      final ByteReader<?> targetFile, List<InternalSignature> intSigs) {
 
     final List<InternalSignature> matchingSigs = getMatchingSignatures(targetFile, intSigs);
     for (final InternalSignature internalSig : matchingSigs) {
@@ -222,7 +173,7 @@ public final class DroidUtils {
             new FileFormatHit(
                 internalSig.getFileFormat(fileFormatIndex),
                 FileFormatHit.HIT_TYPE_POSITIVE_GENERIC_OR_SPECIFIC,
-                internalSig.isSpecific(),
+                true,
                 "");
         targetFile.addHit(fileHit);
       }
@@ -230,40 +181,65 @@ public final class DroidUtils {
   }
 
   private static List<InternalSignature> getMatchingSignatures(
-      ByteReader targetFile, List<InternalSignature> intSigs) {
+      ByteReader<?> targetFile, List<InternalSignature> intSigs) {
 
     List<InternalSignature> matchingSigs = new ArrayList<>();
     if (targetFile.getNumBytes() > 0) {
       for (final InternalSignature internalSig : intSigs) {
-        if (internalSig.matches(targetFile, -1)) {
+        // Maybe we could optimize the match with a specific MAX_BYTES_TO_SCAN by signature type
+        if (internalSig.matches(targetFile, MAX_BYTES_TO_SCAN)) {
           matchingSigs.add(internalSig);
+          // Don't check for another signature
+          break;
         }
       }
     }
     return matchingSigs;
   }
 
-  private static List<InternalSignature> buildInternalSignatures(
-      BinarySignatureIdentifier bsi, String extension) {
-
-    Map<Integer, InternalSignature> intSignsMap = new HashMap<>();
-    List<InternalSignature> signatures = bsi.getSigFile().getSignatures();
-    for (InternalSignature isig : signatures) {
-      for (int i = 0; i < isig.getNumFileFormats(); i++) {
-        FileFormat format = isig.getFileFormat(i);
-        for (String ext : format.getExtensions()) {
-          if (extension.equalsIgnoreCase(ext)) {
-            intSignsMap.put(isig.getID(), isig);
-          }
-        }
-      }
-    }
-    return new ArrayList<>(intSignsMap.values());
-  }
-
   /** Allow lazy initialization of Droid Signatures */
   private static class DroidSignaturesHolder {
 
     private static final BinarySignatureIdentifier INSTANCE = initDroidSignatures();
+
+    /**
+     * Initialise les identifiants binaires des signatures Droid à partir de la ressource par
+     * défaut.
+     *
+     * @return les identifiants binaires des signatures
+     */
+    private static BinarySignatureIdentifier initDroidSignatures() {
+      Path signaturePath = null;
+      try (InputStream is = SipUtils.resourceAsStream("droid_signaturefile.xml")) {
+        signaturePath = Files.createTempFile("droid", ".xml");
+        Files.copy(is, signaturePath, StandardCopyOption.REPLACE_EXISTING);
+
+        BinarySignatureIdentifier bsi = DroidUtils.initDroidSignatures(signaturePath);
+        initInternalSignatures(bsi);
+        return bsi;
+
+      } catch (IOException ex) {
+        throw new SipException("Unable to init Droid signatures identifier", ex);
+      } finally {
+        if (signaturePath != null) {
+          try {
+            Files.deleteIfExists(signaturePath);
+          } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+          }
+        }
+      }
+    }
+
+    private static void initInternalSignatures(BinarySignatureIdentifier bsi) {
+      for (InternalSignature signature : bsi.getSigFile().getSignatures()) {
+        for (int i = 0; i < signature.getNumFileFormats(); i++) {
+          for (String extension : signature.getFileFormat(i).getExtensions()) {
+            String ext = extension.toUpperCase();
+            SIGNATURES.computeIfAbsent(ext, k -> new ArrayList<>()).add(signature);
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/java/fr/xelians/sipg/SipFactory.java
+++ b/src/test/java/fr/xelians/sipg/SipFactory.java
@@ -135,7 +135,7 @@ public class SipFactory {
     HashMap<String, ArchiveUnit> map = new HashMap<>();
 
     try (BufferedReader reader = Files.newBufferedReader(csvPath)) {
-      CSVParser parser = CSVFormat.DEFAULT.builder().setDelimiter(';').build().parse(reader);
+      CSVParser parser = CSVFormat.DEFAULT.builder().setDelimiter(';').get().parse(reader);
       for (CSVRecord csvRecord : parser) {
         ArchiveUnit unit = new ArchiveUnit();
         unit.setBinaryPath(Paths.get(TestInit.TEST_RESOURCES + csvRecord.get(2)));

--- a/src/test/java/fr/xelians/sipg/service/DroidTest.java
+++ b/src/test/java/fr/xelians/sipg/service/DroidTest.java
@@ -41,7 +41,7 @@ class DroidTest {
   @Test
   void testSmallPdfDroid() {
     Path path = Paths.get(TestInit.TEST_RESOURCES + "dummy.pdf");
-    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "pdf");
+    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "pdf", true);
     assertEquals(1, results.size());
     assertEquals("fmt/18", results.getFirst().getPuid());
   }
@@ -50,7 +50,7 @@ class DroidTest {
   @Test
   void testMediumPdfDroid() {
     Path path = Paths.get(TestInit.TEST_RESOURCES + "citizenfour.pdf");
-    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "pdf");
+    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "pdf", true);
     assertEquals(1, results.size());
     assertEquals("fmt/19", results.getFirst().getPuid());
   }
@@ -58,14 +58,14 @@ class DroidTest {
   @Test
   void testPlainTextDroid() {
     Path path = Paths.get(TestInit.TEST_RESOURCES + "dummy.txt");
-    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "txt");
+    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "txt", true);
     assertEquals("x-fmt/111", results.getFirst().getPuid());
   }
 
   @Test
   void testJsonDroid() {
     Path path = Paths.get(TestInit.TEST_RESOURCES + "minisip.json");
-    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "json");
+    List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "json", true);
     assertEquals("fmt/817", results.getFirst().getPuid());
   }
 
@@ -75,7 +75,7 @@ class DroidTest {
     Path path = Paths.get(TestInit.TEST_RESOURCES + "citizenfour.pdf");
 
     for (int i = 0; i < 1000; i++) {
-      List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "pdf");
+      List<IdentificationResult> results = DroidUtils.matchBinarySignatures(path, "pdf", true);
       assertEquals("fmt/19", results.getFirst().getPuid());
     }
   }

--- a/src/test/java/fr/xelians/sipg/service/sedajson/SedaJsonTest.java
+++ b/src/test/java/fr/xelians/sipg/service/sedajson/SedaJsonTest.java
@@ -438,7 +438,7 @@ class SedaJsonTest {
       if (id != null) {
         ids.add(id.asText());
       }
-      node.fields().forEachRemaining(e -> collectXmlIds(e.getValue(), ids));
+      node.properties().forEach(e -> collectXmlIds(e.getValue(), ids));
     } else if (node.isArray()) {
       node.forEach(child -> collectXmlIds(child, ids));
     }


### PR DESCRIPTION
- Move no-arg initDroidSignatures() into DroidSignaturesHolder (Sonar)
- Add explicit matchExtension flag to matchBinarySignatures()
- Update callers (SEDA/FNTC converters, tests) for the new signature
- Add jspecify dependency and bump version to 1.48
- Adapt to commons-csv (.get()) and Jackson (.properties()) API changes